### PR TITLE
Updated  to fix  when printing

### DIFF
--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -154,15 +154,13 @@ class Protocol:
         return '''\
 EWS url: %s
 Product version (according to XSD): %s
-API version (according to SOAP headers): %s
 Full name: %s
 Build numbers: %s
 EWS auth: %s
 XSD auth: %s''' % (
             self.ews_url,
-            self.version.shortname,
             self.version.api_version,
-            self.version.name,
+            self.version.fullname,
             self.version.build,
             self.ews_auth_type,
             self.docs_auth_type,


### PR DESCRIPTION
Fix for issue #10.

Not really that much to say, removed `self.version.shortname` (and the relevant string line) since it doesn't exist and changed `self.version.name` to `self.version.fullname`- a property of `class Version`.

I did notice the classmethod `_get_shortname_from_docs()` in `Version`. Is that supposed to be what provides the shortname? If so, should it be a staticmethod instead of a classmethod? If that's the case, I'm happy to make those changes as well.