### PR TITLE
Fix unicode error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,14 @@
 To upload to PyPI:
    python setup.py sdist bdist_wheel upload
 """
+import io
 import os
 
 from setuptools import setup
 
 
 def read(fname):
-    with open(os.path.join(os.path.dirname(__file__), fname)) as f:
+    with io.open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8') as f:
         return f.read()
 
 setup(


### PR DESCRIPTION
Fix installation errors in a non-unicode environment for `python3`:
```sh
Traceback (most recent call last):
  File "nix_run_setup.py", line 8, in <module>
    exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
  File "setup.py", line 22, in <module>
    long_description=read('README.rst'),
  File "setup.py", line 14, in read
    return f.read()
  File "/nix/store/4h6i7al6skhnpa3z3dbgbyd38b04zgbp-python3-3.5.3/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 16106: ordinal not in range(128)
```
Tested this fix for `python27` and `python35`.