### PR TITLE
Fix invalid reference to getsockname

### DIFF
--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -270,6 +270,6 @@ class EWSSession(requests.sessions.Session):
         for _ in range(pool.pool.qsize()):
             conn = pool._get_conn()
             if conn.sock:
-                log.debug('Closing socket %s', text_type(conn.sock.getsockname()))
+                log.debug('Closing socket %s', text_type(conn.sock.socket.getsockname()))
                 conn.sock.shutdown(socket.SHUT_RDWR)
                 conn.sock.close()

--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -271,5 +271,5 @@ class EWSSession(requests.sessions.Session):
             conn = pool._get_conn()
             if conn.sock:
                 log.debug('Closing socket %s', text_type(conn.sock.socket.getsockname()))
-                conn.sock.shutdown(socket.SHUT_RDWR)
+                conn.sock.socket.shutdown(socket.SHUT_RDWR)
                 conn.sock.close()


### PR DESCRIPTION
`protocol.EWSSession.close_socket` makes an invalid reference to `WrappedSocket.getsockname`.

Changed to `WrappedSocket.socket.getsockname`