### PR TITLE
Unable to login

### DIFF
--- a/exchangelib/properties.py
+++ b/exchangelib/properties.py
@@ -174,7 +174,7 @@ class ItemId(EWSElement):
     CHANGEKEY_ATTR = 'ChangeKey'
     FIELDS = [
         IdField('id', field_uri=ID_ATTR, is_required=True),
-        IdField('changekey', field_uri=CHANGEKEY_ATTR, is_required=True),
+        IdField('changekey', field_uri=CHANGEKEY_ATTR, is_required=False),
     ]
 
     __slots__ = ('id', 'changekey')
@@ -236,15 +236,15 @@ class Mailbox(EWSElement):
     FIELDS = [
         TextField('name', field_uri='Name'),
         EmailField('email_address', field_uri='EmailAddress'),
+        ChoiceField('routing_type', field_uri='RoutingType', choices={Choice('SMTP')}, default='SMTP'),
         ChoiceField('mailbox_type', field_uri='MailboxType', choices={
             Choice('Mailbox'), Choice('PublicDL'), Choice('PrivateDL'), Choice('Contact'), Choice('PublicFolder'),
             Choice('Unknown'), Choice('OneOff')
         }, default='Mailbox'),
         EWSElementField('item_id', value_cls=ItemId, is_read_only=True),
-        ChoiceField('routing_type', field_uri='RoutingType', choices={Choice('SMTP')}, default='SMTP'),
     ]
 
-    __slots__ = ('name', 'email_address', 'mailbox_type', 'item_id', 'routing_type')
+    __slots__ = ('name', 'email_address', 'routing_type', 'mailbox_type', 'item_id')
 
     def clean(self, version=None):
         super(Mailbox, self).clean(version=version)


### PR DESCRIPTION
These lines of code fail for me:
```
credentials = Credentials(username=username, password=password)
configEwsAcc = Configuration(server=server, credentials=credentials)
ewsAccount = Account(primary_smtp_address=private_mail_address, config=configEwsAcc, autodiscover=False, access_type=DELEGATE)
```

It fails with the following XML-message
```
<?xml version="1.0" encoding="utf-8"?>
<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
  <s:Body>
    <s:Fault>
      <faultcode xmlns:a="http://schemas.microsoft.com/exchange/services/2006/types">a:ErrorSchemaValidation</faultcode>
      <faultstring xml:lang="de-CH">The request failed schema validation: The element 'Mailbox' in namespace 'http://schemas.microsoft.com/exchange/services/2006/types' has invalid child element 'RoutingType' in namespace 'http://schemas.microsoft.com/exchange/services/2006/types'. List of possible elements expected: 'ItemId' in namespace 'http://schemas.microsoft.com/exchange/services/2006/types'.</faultstring>
      <detail>
        <e:ResponseCode xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">ErrorSchemaValidation</e:ResponseCode>
        <e:Message xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">The request failed schema validation.</e:Message>
        <t:MessageXml xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
          <t:LineNumber>1</t:LineNumber>
          <t:LinePosition>1006</t:LinePosition>
          <t:Violation>The element 'Mailbox' in namespace 'http://schemas.microsoft.com/exchange/services/2006/types' has invalid child element 'RoutingType' in namespace 'http://schemas.microsoft.com/exchange/services/2006/types'. List of possible elements expected: 'ItemId' in namespace 'http://schemas.microsoft.com/exchange/services/2006/types'.</t:Violation>
        </t:MessageXml>
      </detail>
    </s:Fault>
  </s:Body>
</s:Envelope>
```

And I'm not kidding you here, but the problem is the order of the children elements in the request XML. Basically you have to strictly follow the order of the EWS documentation ([MSDN Doc](https://msdn.microsoft.com/en-us/library/aa565036(v=exchg.150).aspx)). See also the blogpost here: [MSDN Blogpost](https://blogs.msdn.microsoft.com/dhruvkh/2011/10/18/the-request-failed-schema-validation-but-why/)

Also this pull request contains a change in changekey for ItemId that it is not mandatory anymore (you can request by the id only and get a response with the current changekey)