### PR TITLE
Add CopyItem functionality

### DIFF
--- a/exchangelib/items.py
+++ b/exchangelib/items.py
@@ -326,6 +326,16 @@ class Item(RegisterMixIn):
         for f in self.FIELDS:
             setattr(self, f.name, getattr(fresh_item, f.name))
 
+    def copy(self, to_folder):
+        if not self.account:
+            raise ValueError('Item must have an account')
+        if not self.item_id:
+            raise ValueError('Item must have an ID')
+        res = self.account.bulk_copy(ids=[self], to_folder=to_folder)
+        self.folder = to_folder
+
+        return res[0]
+
     def move(self, to_folder):
         if not self.account:
             raise ValueError('Item must have an account')

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -1239,6 +1239,38 @@ class MoveItem(EWSAccountService):
         return moveeitem
 
 
+class CopyItem(EWSAccountService):
+    """
+    MSDN: https://msdn.microsoft.com/en-us/library/office/aa565012(v=exchg.150).aspx
+    """
+    SERVICE_NAME = 'CopyItem'
+
+    def call(self, items, to_folder):
+        return self._get_elements(payload=self.get_payload(
+            items=items,
+            to_folder=to_folder,
+        ))
+
+    def get_payload(self, items, to_folder):
+        from .properties import ItemId
+        copyitem = create_element('m:%s' % self.SERVICE_NAME)
+
+        tofolderid = create_element('m:ToFolderId')
+        set_xml_value(tofolderid, to_folder, version=self.account.version)
+        copyitem.append(tofolderid)
+        item_ids = create_element('m:ItemIds')
+        is_empty = True
+        for item in items:
+            is_empty = False
+            item_id = ItemId(*(item if isinstance(item, tuple) else (item.item_id, None)))
+            log.debug('Copying item %s to %s', item, to_folder)
+            set_xml_value(item_ids, item_id, version=self.account.version)
+        if is_empty:
+            raise ValueError('"items" must not be empty')
+        copyitem.append(item_ids)
+        return copyitem
+
+
 class ResolveNames(EWSService):
     """
     MSDN: https://msdn.microsoft.com/en-us/library/office/aa565329(v=exchg.150).aspx


### PR DESCRIPTION
* Add bulk_copy method to account.py
* Add copy method to items.py
* Add CopyItem to services.py
* Add tests for bulk_copy and copy
* Based off implementation for MoveItem
* Returns True/False based on success of copy operation instead of item ids and change keys as in MoveItem