### PR TITLE
Add a MANIFEST.in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Change Log
 HEAD
 ----
 
+-   Add a MAINFEST.in to ensure the LICENSE file gets included + CHANGELOG.md/README.md to sdist tarball
 -   Renamed `Item.item_id`, `Folder.folder_id` and `Occurrence.item_id` to just `Item.id`,
     `Folder.id` and `Occurrence.id`, respectively. This removes redundancy in the naming
     and provides consistency. For all classes that have an ID, the ID can now be accessed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include MANIFEST.in
+include LICENSE
+include CHANGELOG.md
+include README.md


### PR DESCRIPTION
- Add to ensure sdist includes the LICENSE file and other .md files
- This should help stop `pip wheel` builds of the module failing due to no LICENSE file existing

#437 