### PR TITLE
Fixes #448: Crash in Openshift / Kubernetes

### DIFF
--- a/exchangelib/autodiscover.py
+++ b/exchangelib/autodiscover.py
@@ -51,7 +51,8 @@ def shelve_filename():
     try:
         user = getpass.getuser()
     except KeyError:
-        user = "exchangelib"
+        # getuser() fails on some systems. Provide a sane default. See issue #448
+        user = 'exchangelib'
     return 'exchangelib.cache.{user}.py{major}{minor}'.format(user=user, major=major, minor=minor)
 
 

--- a/exchangelib/autodiscover.py
+++ b/exchangelib/autodiscover.py
@@ -48,7 +48,10 @@ def shelve_filename():
     # 'shelve' may pickle objects using different pickle protocol versions. Append the python major+minor version
     # numbers to the filename. Also append the username, to avoid permission errors.
     major, minor = sys.version_info[:2]
-    user = getpass.getuser()
+    try:
+        user = getpass.getuser()
+    except KeyError:
+        user = "exchangelib"
     return 'exchangelib.cache.{user}.py{major}{minor}'.format(user=user, major=major, minor=minor)
 
 


### PR DESCRIPTION
When using exchangelib in Openshift / Kubernetes where containers are
run as random userids, the getpwuid() produces an error.
With this change a default value is provided