### PR TITLE
Create a way to save drafts of replies and forwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,16 @@ m.forward(
     to_recipients=['carl@example.com', 'denice@example.com']
 )
 
+# You can also edit a draft of a reply or forward
+forward_draft = m.create_forward(
+    subject='Fwd: foo',
+    body='Hey, look at this!',
+    to_recipients=['carl@example.com', 'denice@example.com']
+).save(a.drafts) # gives you back the item
+forward_draft.reply_to = 'eric@example.com'
+forward_draft.attach(FileAttachment(name='my_file.txt', content='hello world'.encode('utf-8')))
+forward_draft.send() # now our forward has an extra reply_to field and an extra attachment.
+
 # EWS distinquishes between plain text and HTML body contents. If you want to send HTML body 
 # content, use the HTMLBody helper. Clients will see this as HTML and display the body correctly:
 item.body = HTMLBody('<html><body>Hello happy <blink>OWA user!</blink></body></html>')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5736,7 +5736,11 @@ class MessagesTest(BaseItemTest):
                 time.sleep(1)
         else:
             assert False, 'Gave up waiting for the reply to show up in the inbox'
-        self.account.bulk_delete([sent_item, reply])
+        reply2 = sent_item.create_forward(subject=new_subject, body='Hello reply', to_recipients=[item.author])
+        reply2 = reply2.save(self.account.drafts)
+        self.assertIsInstance(reply2, Message)
+        
+        self.account.bulk_delete([sent_item, reply, reply2])
 
     def test_mime_content(self):
         # Tests the 'mime_content' field


### PR DESCRIPTION
The strategy is to save forwards/replies and fetch them so you can edit them as items.
Relates to issue #476