### PR TITLE
Set a default folder_class for new folders

### DIFF
--- a/exchangelib/folders.py
+++ b/exchangelib/folders.py
@@ -372,6 +372,9 @@ class Folder(RegisterMixIn, SearchableMixIn):
         super(Folder, self).clean(version=version)
         if self.root and not isinstance(self.root, RootOfHierarchy):
             raise ValueError("'root' %r must be a RootOfHierarchy instance" % self.root)
+        # Set a default folder class for new folders. A folder class cannot be changed after saving.
+        if self.folder_id is None and self.folder_class is None:
+            self.folder_class = self.CONTAINER_CLASS
 
     @property
     def parent(self):


### PR DESCRIPTION
Calendar folders do not show up in OWA/Outlook calendar lists unless the folder has the correct folder_class.

Fixes #489