### PR TITLE
update_fields argument to save() must be a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ item.subject = 'bar'
 # versions of Exchange.
 print(CalendarItem.FIELDS)
 item.save()  # When the items has an item_id, this will update the item
-item.save(update_fields=['subject'])  # Only updates certain fields
+item.save(update_fields=['subject'])  # Only updates certain fields - must be a list
 item.save(send_meeting_invitations=SEND_ONLY_TO_CHANGED)  # Send invites only to attendee changes
 item.delete()  # Hard deletinon
 item.delete(send_meeting_cancellations=SEND_ONLY_TO_ALL)  # Send cancellations to all attendees

--- a/exchangelib/items.py
+++ b/exchangelib/items.py
@@ -245,6 +245,8 @@ class Item(RegisterMixIn):
 
     def save(self, update_fields=None, conflict_resolution=AUTO_RESOLVE, send_meeting_invitations=SEND_TO_NONE):
         if self.id:
+            if update_fieldnames and not isinstance(update_fieldnames, list):
+                raise ValueError('update_fields, if set, must be a list')
             item_id, changekey = self._update(
                 update_fieldnames=update_fields,
                 message_disposition=SAVE_ONLY,


### PR DESCRIPTION
Two changes in this PR, both apropos #498 - document a little more explicitly that the `update_fields` argument to `save` must be a list, and add a check that raises `ValueError` if it isn't.