### PR TITLE
Wrong check for datetime instance

### DIFF
--- a/exchangelib/ewsdatetime.py
+++ b/exchangelib/ewsdatetime.py
@@ -102,7 +102,7 @@ class EWSDateTime(datetime.datetime):
 
     @classmethod
     def from_datetime(cls, d):
-        if d.__class__ != datetime.datetime:
+        if not isinstance(d, datetime.datetime):
             raise ValueError("%r must be a datetime instance" % d)
         if d.tzinfo is None:
             tz = None


### PR DESCRIPTION
I had an error with python-3.6.5 when the computer system timezone and the timezone of the calendar item were the same (e.g. both Europe/Brussels), because the internal python implementation returns in datetime.astimezone(tz) just self, which is a EWSDateTime, hence d.__class__ != datetime.datetime is triggered to be true.
What we really are interested in, is whether it is an instance of datetime, so we can treat it like one.