### PR TITLE
added ExpandDL service function for expanding public distribution lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,10 @@ for mailbox in a.protocol.resolve_names(['ann@example.com', 'bart@example.com'])
 for mailbox, contact in a.protocol.resolve_names(['anne', 'bart'], return_full_contact_data=True):
     print(mailbox.email_address, contact.display_name)
 
+# Get all mailboxes on a distribution list
+for mailbox in a.protocol.expand_dl('distro@example.com'):
+    print(mailbox.email_address)
+
 # Get searchable mailboxes. This method is only available to users who have been assigned
 # the Discovery Management RBAC role. (This feature works on Exchange 2013 onwards)
 for mailbox in a.protocol.get_searchable_mailboxes():

--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -369,13 +369,13 @@ class Protocol(with_metaclass(CachingProtocol, BaseProtocol)):
             contact_data_shape=shape,
         ))
 
-    def expand_dl(self, dl_mailbox):
+    def expand_dl(self, distribution_list):
         """ Expand distribution list into it's members
 
-        :param dl_mailbox: Mailbox of the distribution list to expand
-        :return: A list of Mailbox items
+        :param distribution_list: SMTP address of the distribution list to expand
+        :return: List of Mailbox items that are members of the distribution list
         """
-        return list(ExpandDL(protocol=self).call(distribution_list=dl_mailbox))
+        return list(ExpandDL(protocol=self).call(distribution_list=distribution_list))
 
     def get_searchable_mailboxes(self, search_filter=None, expand_group_membership=False):
         """This method is only available to users who have been assigned the Discovery Management RBAC role. See

--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -22,7 +22,7 @@ from .credentials import Credentials
 from .errors import TransportError, SessionPoolMinSizeReached
 from .properties import FreeBusyViewOptions, MailboxData, TimeWindow, TimeZone
 from .services import GetServerTimeZones, GetRoomLists, GetRooms, ResolveNames, GetUserAvailability, \
-    GetSearchableMailboxes
+    GetSearchableMailboxes, ExpandDL
 from .transport import get_auth_instance, get_service_authtype, get_docs_authtype, AUTH_TYPE_MAP, DEFAULT_HEADERS
 from .util import split_url
 from .version import Version, API_VERSIONS
@@ -368,6 +368,14 @@ class Protocol(with_metaclass(CachingProtocol, BaseProtocol)):
             unresolved_entries=names, return_full_contact_data=return_full_contact_data, search_scope=search_scope,
             contact_data_shape=shape,
         ))
+
+    def expand_dl(self, dl_mailbox):
+        """ Expand distribution list into it's members
+
+        :param dl_mailbox: Mailbox of the distribution list to expand
+        :return: A list of Mailbox items
+        """
+        return list(ExpandDL(protocol=self).call(distribution_list=dl_mailbox))
 
     def get_searchable_mailboxes(self, search_filter=None, expand_group_membership=False):
         """This method is only available to users who have been assigned the Discovery Management RBAC role. See

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -1686,6 +1686,33 @@ class ResolveNames(EWSService):
         return payload
 
 
+class ExpandDL(EWSService):
+    """
+    MSDN: https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/expanddl-operation
+    """
+    SERVICE_NAME = 'ExpandDL'
+    element_container_name = '{%s}DLExpansion' % MNS
+    ERRORS_TO_CATCH_IN_RESPONSE = ErrorNameResolutionNoResults
+    WARNINGS_TO_IGNORE_IN_RESPONSE = ErrorNameResolutionMultipleResults
+
+    def call(self, distribution_list):
+        from .properties import Mailbox
+        elements = self._get_elements(payload=self.get_payload(distribution_list=distribution_list))
+        for elem in elements:
+            if isinstance(elem, ErrorNameResolutionNoResults):
+                continue
+            if isinstance(elem, Exception):
+                raise elem
+            yield Mailbox.from_xml(elem, account=None)
+
+    def get_payload(self, distribution_list):
+        payload = create_element('m:%s' % self.SERVICE_NAME)
+        dl_mailbox = create_element('m:Mailbox')
+        add_xml_child(dl_mailbox, 't:EmailAddress', distribution_list.email_address)
+        payload.append(dl_mailbox)
+        return payload
+
+
 class GetAttachment(EWSAccountService):
     """
     MSDN: https://msdn.microsoft.com/en-us/library/office/aa494316(v=exchg.150).aspx

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -1699,8 +1699,6 @@ class ExpandDL(EWSService):
         from .properties import Mailbox
         elements = self._get_elements(payload=self.get_payload(distribution_list=distribution_list))
         for elem in elements:
-            if isinstance(elem, ErrorNameResolutionNoResults):
-                continue
             if isinstance(elem, Exception):
                 raise elem
             yield Mailbox.from_xml(elem, account=None)

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -1708,7 +1708,7 @@ class ExpandDL(EWSService):
     def get_payload(self, distribution_list):
         payload = create_element('m:%s' % self.SERVICE_NAME)
         dl_mailbox = create_element('m:Mailbox')
-        add_xml_child(dl_mailbox, 't:EmailAddress', distribution_list.email_address)
+        add_xml_child(dl_mailbox, 't:EmailAddress', distribution_list)
         payload.append(dl_mailbox)
         return payload
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1784,11 +1784,8 @@ class CommonTest(EWSTest):
         )
 
     def test_expanddl(self):
-        try:
+        with self.assertRaises(ErrorNameResolutionNoResults):
             self.account.protocol.expand_dl('non_existent_distro@example.com')
-            self.assertFail("expanding a non existent distribution list should throw ErrorNameResolutionNoResults exception")
-        except ErrorNameResolutionNoResults:
-            pass
 
     def test_oof_settings(self):
         oof = OofSettings(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1783,6 +1783,12 @@ class CommonTest(EWSTest):
             {'anne@example.com', 'john@example.com'}
         )
 
+    def test_expanddl(self):
+        self.assertEqual(
+            len(self.account.protocol.expand_dl('non_existent_distro@example.com')),
+            0
+        )
+
     def test_oof_settings(self):
         oof = OofSettings(
             state=OofSettings.ENABLED,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1784,10 +1784,11 @@ class CommonTest(EWSTest):
         )
 
     def test_expanddl(self):
-        self.assertEqual(
-            len(self.account.protocol.expand_dl('non_existent_distro@example.com')),
-            0
-        )
+        try:
+            self.account.protocol.expand_dl('non_existent_distro@example.com')
+            self.assertFail("expanding a non existent distribution list should throw ErrorNameResolutionNoResults exception")
+        except ErrorNameResolutionNoResults:
+            pass
 
     def test_oof_settings(self):
         oof = OofSettings(


### PR DESCRIPTION
I implemented the ExpandDL operation from the [Expand operation MSDN page](https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/expanddl-operation)

usage is similar to the non-account resolve_names method. Example:

```
from exchangelib import Account

a = Account(...)

# Get member mailboxes from the smtp address of a distribution list
for mailbox in a.protocol.expand_dl('distro@example.com'):
    print(mailbox.email_address)
```