### PR TITLE
[ewsdatetime] Support defensive comparisons in EWSTimeZone.__eq__

### DIFF
--- a/exchangelib/ewsdatetime.py
+++ b/exchangelib/ewsdatetime.py
@@ -173,7 +173,7 @@ class EWSTimeZone(object):
         # Microsoft timezones are less granular than pytz, so an EWSTimeZone created from 'Europe/Copenhagen' may return
         # from the server as 'Europe/Copenhagen'. We're catering for Microsoft here, so base equality on the Microsoft
         # timezone ID.
-        if not isinstance(other, EWSTimeZone):
+        if not isinstance(other, self.__class__):
             return NotImplemented
         return self.ms_id == other.ms_id
 

--- a/exchangelib/ewsdatetime.py
+++ b/exchangelib/ewsdatetime.py
@@ -173,6 +173,8 @@ class EWSTimeZone(object):
         # Microsoft timezones are less granular than pytz, so an EWSTimeZone created from 'Europe/Copenhagen' may return
         # from the server as 'Europe/Copenhagen'. We're catering for Microsoft here, so base equality on the Microsoft
         # timezone ID.
+        if not isinstance(other, EWSTimeZone):
+            return NotImplemented
         return self.ms_id == other.ms_id
 
     def __hash__(self):


### PR DESCRIPTION
Do not assume other is also an EWSTimeZone instance.

https://github.com/ecederstrand/exchangelib/issues/557

Signed-off-by: Earl Chew <earl_chew@yahoo.com>