### PR TITLE
Basic implementation of the client credentials grant (backend) OAuth2 flow

### DIFF
--- a/exchangelib/credentials.py
+++ b/exchangelib/credentials.py
@@ -122,3 +122,23 @@ class ServiceAccount(Credentials):
         value = datetime.datetime.now() + datetime.timedelta(seconds=seconds)
         with self._back_off_lock:
             self._back_off_until = value
+
+
+class OAuth2BackendClientCredentials(ServiceAccount):
+    def __init__(self, client_id, client_secret, tenant_id, max_wait=3600):
+        super(OAuth2BackendClientCredentials, self).__init__('', '', max_wait)
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.tenant_id = tenant_id
+
+    def __eq__(self, other):
+        return self.client_id == other.client_id and self.client_secret == other.client_secret and self.tenant_id == other.tenant_id
+
+    def __hash__(self):
+        return hash((self.client_id, self.client_secret, self.tenant_id))
+
+    def __repr__(self):
+        return self.__class__.__name__ + repr((self.client_id, '********'))
+
+    def __str__(self):
+        return self.client_id

--- a/exchangelib/version.py
+++ b/exchangelib/version.py
@@ -167,6 +167,7 @@ EXCHANGE_2013 = Build(15, 0)
 EXCHANGE_2013_SP1 = Build(15, 0, 847)
 EXCHANGE_2016 = Build(15, 1)
 EXCHANGE_2019 = Build(15, 2)
+EXCHANGE_O365 = Build(15, 20)
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
This works as expected with both OAuth2 and Basic.  It only supports the client credentials grant flow for OAuth2, which is used by applications to authenticate against O365 tenants.

You also have to explicitly specify a version when constructing the Configuration object because the version-guessing method will fail due to authentication issues otherwise-- I didn't have a chance to fix that.

This is a little bit hacky, and it may not be what other developers need, but you said you were open to providing feedback on a PR. :)