### PR TITLE
Cleanup the thread pool on Protocol close

### DIFF
--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -314,6 +314,14 @@ class Protocol(with_metaclass(CachingProtocol, BaseProtocol)):
         thread_poolsize = 4 * self._session_pool_size
         return ThreadPool(processes=thread_poolsize)
 
+    def close(self):
+        # Close the thread pool before closing the session pool to ensure all sessions are released.
+        if "thread_pool" in self.__dict__:
+            self.thread_pool.close()
+            self.thread_pool.join()
+            del self.__dict__["thread_pool"]
+        super(Protocol, self).close()
+
     def get_timezones(self, timezones=None, return_full_timezone_data=False):
         """ Get timezone definitions from the server
 


### PR DESCRIPTION
Not closing the thread pool leaves unused threads until garbage collection. This can easily balloon in a multi-account application.