### PR TITLE
Changes to Enable Shared Mailbox Calendars access

### DIFF
--- a/exchangelib/account.py
+++ b/exchangelib/account.py
@@ -572,13 +572,14 @@ class Account(object):
             ))
         )
 
-    def fetch(self, ids, folder=None, only_fields=None, chunk_size=None):
+    def fetch(self, ids, folder=None, only_fields=None, chunk_size=None, shape=ID_ONLY):
         """ Fetch items by ID
 
         :param ids: an iterable of either (id, changekey) tuples or Item objects.
         :param folder: used for validating 'only_fields'
         :param only_fields: A list of string or FieldPath items specifying the fields to fetch. Default to all fields
         :param chunk_size: The number of items to send to the server in a single request
+        :param shape: Property Shape / Set to be returned. Defaults to IdOnly
         :return: A generator of Item objects, in the same order as the input
         """
         validation_folder = folder or Folder(root=self.root)  # Default to a folder type that supports all item types
@@ -594,10 +595,10 @@ class Account(object):
             for field in only_fields:
                 validation_folder.validate_item_field(field=field, version=self.version)
             additional_fields = validation_folder.normalize_fields(fields=only_fields)
-        # Always use IdOnly here, because AllProperties doesn't actually get *all* properties
+        # Use IdOnly here by default, AllProperties doesn't actually get *all* properties
         for i in self._consume_item_service(service_cls=GetItem, items=ids, chunk_size=chunk_size, kwargs=dict(
                 additional_fields=additional_fields,
-                shape=ID_ONLY,
+                shape=shape,
         )):
             if isinstance(i, Exception):
                 yield i

--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -82,7 +82,7 @@ class BaseProtocol(object):
         self._headers = {}
         self.extra_headers = {}
 
-    def _get_extra_headers(self, account):
+    def get_extra_headers(self, account):
         """Generate extra HTTP headers"""
         if account:
             # See

--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -78,6 +78,19 @@ class BaseProtocol(object):
         self._session_pool = self._create_session_pool()
         self._session_pool_lock = Lock()
 
+        # custom headers for advanced usage / testing
+        self._headers = {}
+        self.extra_headers = {}
+
+    def _get_extra_headers(self, account):
+        """Generate extra HTTP headers"""
+        if account:
+            # See
+            # https://blogs.msdn.microsoft.com/webdav_101/2015/05/11/best-practices-ews-authentication-and-access-issues/
+            self._headers.update({'X-AnchorMailbox': account.primary_smtp_address})
+            self._headers.update(self.extra_headers)
+        return self._headers
+
     @property
     def service_endpoint(self):
         return self.config.service_endpoint

--- a/exchangelib/services/common.py
+++ b/exchangelib/services/common.py
@@ -18,7 +18,7 @@ from ..errors import EWSWarning, TransportError, SOAPError, ErrorTimeoutExpired,
     ErrorCannotDeleteTaskOccurrence, ErrorMimeContentConversionFailed, ErrorRecurrenceHasNoOccurrence, \
     ErrorNoPublicFolderReplicaAvailable, MalformedResponseError, ErrorExceededConnectionCount, \
     SessionPoolMinSizeReached, ErrorIncorrectSchemaVersion, ErrorInvalidRequest
-from ..transport import wrap, extra_headers
+from ..transport import wrap
 from ..util import chunkify, create_element, add_xml_child, get_xml_attr, to_xml, post_ratelimited, \
     xml_to_str, set_xml_value, SOAPNS, TNS, MNS, ENS, ParseError
 
@@ -129,7 +129,7 @@ class EWSService(object):
                 protocol=self.protocol,
                 session=self.protocol.get_session(),
                 url=self.protocol.service_endpoint,
-                headers=extra_headers(account=account),
+                headers=self.protocol._get_extra_headers(account=account),
                 data=wrap(content=payload, version=api_version, account=account),
                 allow_redirects=False,
                 stream=self.streaming,

--- a/exchangelib/services/common.py
+++ b/exchangelib/services/common.py
@@ -129,7 +129,7 @@ class EWSService(object):
                 protocol=self.protocol,
                 session=self.protocol.get_session(),
                 url=self.protocol.service_endpoint,
-                headers=self.protocol._get_extra_headers(account=account),
+                headers=self.protocol.get_extra_headers(account=account),
                 data=wrap(content=payload, version=api_version, account=account),
                 allow_redirects=False,
                 stream=self.streaming,


### PR DESCRIPTION
To Get this Library working with Shared Mailbox Calendars I had to make some modifications

A lot of this was based on comparing logs of working code in from Microsoft.Exchange.WebServices library with soap xml in python

see:

https://stackoverflow.com/questions/42596672/accessing-other-calendars-in-exchangelib/
https://stackoverflow.com/questions/23766747/ews-access-all-shared-calendars/
https://stackoverflow.com/questions/24123416/multiple-calender-in-exchange-web-service/

I have some sample code to show this working as well

Before I wasn't able to access Shared Calendars, but it appears it's necessary to modify the Item Traversal type to Associated for this to work.

Also I noticed in the SOAP xml the usage of <code>X-PreferServerAffinity</code> set to <code>true</code> when working with shared calendars in ews, so I added customisable <code>extra_headers</code> property for testing

```python
from exchangelib import Configuration, DELEGATE, Account, ExtendedProperty, Credentials
from exchangelib.services import ResolveNames
from exchangelib.items import ASSOCIATED, ALL_PROPERTIES

# ...

# shared / other people's calendars are stored in Common Views
commonview = [f for f in account.root.walk() if f.name == "Common Views"][0]

qs = commonview.all()

commonviewfolders = list(qs.filter(subject__icontains="sharedmailboxname"))
# list will be emtpy and cannot find results
print(commonviewfolders)

qs.depth = ASSOCIATED
commonviewfolders = list(qs.filter(subject__icontains="sharedmailboxname"))
# now we added property set the result appears
print(commonviewfolders)


# reference
#  https://docs.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxprops/bb313cd3-2aa8-4b7b-b924-8068f778ea3d
class PidTagWlinkAddressBookEID(ExtendedProperty):
    property_tag = 0x6854
    property_type = "Binary"

def strip_resolvename(x):
    """ad hoc function for removing id from PidTagWlinkAddressBookEID"""
    endx = len(x) - 1
    while (endx > 0):
        endx -= 1
        if x[endx] != 0:
            endx += 1
            break
    stx = endx
    while (stx > 0):
        stx -= 1
        if (x[stx] == 0):
            stx += 1
            break
    return (x[stx:endx]).decode('utf-8')

sharedmailboxcalendarfolder = commonviewfolders[-1]

folder.register('PidTagWlinkAddressBookEID', PidTagWlinkAddressBookEID)

# may not be necessary but code sample uses BasePropertySet.FirstClassProperties (the equivalent)
qs.shape = ALL_PROPERTIES

sharedmailboxcalendarfolder = register_properties(sharedmailboxcalendarfolder)

parsed_id = strip_resolvename(sharedmailboxcalendarfolder.PidTagWlinkAddressBookEID)

resolved_names = list(ResolveNames(acc.protocol).call(unresolved_entries=[parsed_id]))

resolved_name = resolved_names[0]

saccount = Account(primary_smtp_address=resolved_name.email_address, config=config, autodiscover=False, access_type=DELEGATE)

# noticed this header in logs / trace of the Microsoft.Exchange.WebServices.dll when working with shared calendars
# moved extra_headers function to property on protocol class
# then bound method to protocol class could modify headers on the fly
saccount.protocol.extra_headers.update({"X-PreferServerAffinity": "true"})

itemz = saccount.calendar.all()

for item in itemz:
    print(item.subject)

print("done.")
```