### PR TITLE
Support OAuth authorization code grant type (#698)

### DIFF
--- a/exchangelib/__init__.py
+++ b/exchangelib/__init__.py
@@ -4,7 +4,8 @@ from .account import Account
 from .attachments import FileAttachment, ItemAttachment
 from .autodiscover import discover
 from .configuration import Configuration
-from .credentials import DELEGATE, IMPERSONATION, Credentials, OAuth2Credentials
+from .credentials import DELEGATE, IMPERSONATION, Credentials, OAuth2Credentials, \
+    OAuth2AuthorizationCodeCredentials
 from .ewsdatetime import EWSDate, EWSDateTime, EWSTimeZone, UTC, UTC_NOW
 from .extended_properties import ExtendedProperty
 from .folders import Folder, FolderCollection, SHALLOW, DEEP
@@ -25,7 +26,7 @@ __all__ = [
     'FileAttachment', 'ItemAttachment',
     'discover',
     'Configuration',
-    'DELEGATE', 'IMPERSONATION', 'Credentials', 'OAuth2Credentials',
+    'DELEGATE', 'IMPERSONATION', 'Credentials', 'OAuth2AuthorizationCodeCredentials', 'OAuth2Credentials',
     'EWSDate', 'EWSDateTime', 'EWSTimeZone', 'UTC', 'UTC_NOW',
     'ExtendedProperty',
     'Folder', 'FolderCollection', 'SHALLOW', 'DEEP',

--- a/exchangelib/credentials.py
+++ b/exchangelib/credentials.py
@@ -7,7 +7,9 @@ See http://blogs.msdn.com/b/exchangedev/archive/2009/06/15/exchange-impersonatio
 """
 from __future__ import unicode_literals
 
+import abc
 import logging
+from threading import Lock
 
 from future.utils import python_2_unicode_compatible
 
@@ -21,7 +23,37 @@ ACCESS_TYPES = (IMPERSONATION, DELEGATE)
 
 
 class BaseCredentials(object):
-    pass
+    """
+    Base for credential storage.
+
+    Establishes a method for refreshing credentials (mostly useful with
+    OAuth, which expires tokens relatively frequently) and provides a
+    lock for synchronizing access to the object around refreshes.
+    """
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self):
+        super(BaseCredentials, self).__init__()
+        self._lock = Lock()
+
+    @property
+    def lock(self):
+        return self._lock
+
+    @abc.abstractmethod
+    def refresh(self, session):
+        """
+        Obtain a new set of valid credentials. This is mostly intended
+        to support OAuth token refreshing, which can happen in long-
+        running applications or those that cache access tokens and so
+        might start with a token close to expiration.
+
+        :param session: requests session asking for refreshed credentials
+        """
+        raise NotImplementedError(
+            'Credentials object does not support refreshing. '
+            + 'See class documentation on automatic refreshing, or subclass and implement refresh().'
+        )
 
 
 @python_2_unicode_compatible
@@ -43,6 +75,7 @@ class Credentials(BaseCredentials, PickleMixIn):
     __slots__ = ('username', 'password', 'type')
 
     def __init__(self, username, password):
+        super(Credentials, self).__init__()
         if username.count('@') == 1:
             self.type = self.EMAIL
         elif username.count('\\') == 1:
@@ -70,14 +103,49 @@ class Credentials(BaseCredentials, PickleMixIn):
 
 @python_2_unicode_compatible
 class OAuth2Credentials(BaseCredentials, PickleMixIn):
-    """Login info for OAuth 2.0 authentication
+    """
+    Login info for OAuth 2.0 client credentials authentication, as well
+    as a base for other OAuth 2.0 grant types.
+
+    This is primarily useful for in-house applications accessing data
+    from a single Microsoft account. For applications that will access
+    multiple tenants' data, the client credentials flow does not give
+    the application enough information to restrict end users' access to
+    the appropriate account. Use OAuth2AuthorizationCodeCredentials and
+    the associated auth code grant type for multi-tenant applications.
+
+    :param client_id: ID of an authorized OAuth application
+    :param client_secret: Secret associated with the OAuth application
+    :param tenant_id: Microsoft tenant ID of the account to access
     """
     __slots__ = ('client_id', 'client_secret', 'tenant_id')
 
     def __init__(self, client_id, client_secret, tenant_id):
+        super(OAuth2Credentials, self).__init__()
         self.client_id = client_id
         self.client_secret = client_secret
         self.tenant_id = tenant_id
+
+    def refresh(self):
+        # Creating a new session gets a new access token, so there's no
+        # work here to refresh the credentials. This implementation just
+        # makes sure we don't raise a NotImplementedError.
+        pass
+
+    def on_token_auto_refreshed(self, access_token):
+        """
+        Called after the access token is refreshed (requests-oauthlib
+        can automatically refresh tokens if given an OAuth client ID and
+        secret, so this is how our copy of the token stays up-to-date).
+        Applications that cache access tokens can override this to store
+        the new token - just remember to call the super() method!
+
+        :param access_token: New token obtained by refreshing
+        """
+        # Ensure we don't update the object in the middle of a new session
+        # being created, which could cause a race
+        with self.lock:
+            self.access_token = access_token
 
     def __eq__(self, other):
         for k in self.__slots__:
@@ -93,3 +161,60 @@ class OAuth2Credentials(BaseCredentials, PickleMixIn):
 
     def __str__(self):
         return self.client_id
+
+
+@python_2_unicode_compatible
+class OAuth2AuthorizationCodeCredentials(OAuth2Credentials, PickleMixIn):
+    """
+    Login info for OAuth 2.0 authentication using the authorization code
+    grant type. This can be used in one of several ways:
+    * Given an authorization code, client ID, and client secret, fetch a
+      token ourselves and refresh it as needed if supplied with a refresh
+      token.
+    * Given an existing access token, refresh token, client ID, and
+      client secret, use the access token until it expires and then
+      refresh it as needed.
+    * Given only an existing access token, use it until it expires. This
+      can be used to let the calling application refresh tokens itself
+      by subclassing and implementing refresh().
+
+    Unlike the base (client credentials) grant, authorization code
+    credentials don't require a Microsoft tenant ID because each access
+    token (and the authorization code used to get the access token) is
+    restricted to a single tenant.
+
+    :params client_id: ID of an authorized OAuth application, required
+        for automatic token fetching and refreshing
+    :params client_secret: Secret associated with the OAuth application
+    :params authorization_code: Code obtained when authorizing the
+        application to access an account. In combination with client_id
+        and client_secret, will be used to obtain an access token.
+    :params access_token: Previously-obtained access token. If a token
+        exists and the application will handle refreshing by itself (or
+        opts not to handle it), this parameter alone is sufficient.
+    """
+    __slots__ = ('access_token', 'authorization_code')
+
+    def __init__(self, client_id=None, client_secret=None, authorization_code=None, access_token=None):
+        super(OAuth2AuthorizationCodeCredentials, self).__init__(client_id, client_secret, tenant_id=None)
+        self.access_token = access_token
+        self.authorization_code = authorization_code
+
+    def __eq__(self, other):
+        for k in self.__slots__:
+            if getattr(self, k) != getattr(other, k):
+                return False
+        return True
+
+    def __hash__(self):
+        return hash((self.access_token['access_token'], self.authorization_code))
+
+    def __repr__(self):
+        return self.__class__.__name__ + ' ' + str(self)
+
+    def __str__(self):
+        client_id = self.client_id
+        credential = '[access_token]' if self.access_token is not None else \
+            ('[authorization code]' if self.authorization_code is not None else None)
+        description = ' '.join(filter(None, [client_id, credential]))
+        return description or '[underspecified credentials]'

--- a/exchangelib/credentials.py
+++ b/exchangelib/credentials.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals
 
 import abc
 import logging
-from threading import Lock
+from threading import RLock
 
 from future.utils import python_2_unicode_compatible
 
@@ -34,7 +34,7 @@ class BaseCredentials(object):
 
     def __init__(self):
         super(BaseCredentials, self).__init__()
-        self._lock = Lock()
+        self._lock = RLock()
 
     @property
     def lock(self):
@@ -126,7 +126,7 @@ class OAuth2Credentials(BaseCredentials, PickleMixIn):
         self.client_secret = client_secret
         self.tenant_id = tenant_id
 
-    def refresh(self):
+    def refresh(self, session):
         # Creating a new session gets a new access token, so there's no
         # work here to refresh the credentials. This implementation just
         # makes sure we don't raise a NotImplementedError.

--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -272,7 +272,9 @@ class BaseProtocol(object):
             # We don't know (or need) the Microsoft tenant ID. Use
             # common/ to let Microsoft select the appropriate tenant
             # for the provided authorization code or refresh token.
-            token_url = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+            #
+            # Suppress looks-like-password warning from Bandit.
+            token_url = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'  # nosec
 
             client_params = {}
             has_token = self.credentials.access_token is not None
@@ -290,15 +292,14 @@ class BaseProtocol(object):
                 # covers cases where the caller doesn't have access to
                 # the client secret but is working with a service that
                 # can provide it refreshed tokens on a limited basis).
-                session_params = {
-                    **session_params,
+                session_params.update({
                     'auto_refresh_kwargs': {
                         'client_id': self.credentials.client_id,
                         'client_secret': self.credentials.client_secret,
                     },
                     'auto_refresh_url': token_url,
                     'token_updater': self.credentials.on_token_auto_refreshed,
-                }
+                })
             client = WebApplicationClient(self.credentials.client_id, **client_params)
         else:
             token_url = 'https://login.microsoftonline.com/%s/oauth2/v2.0/token' % self.credentials.tenant_id
@@ -312,7 +313,7 @@ class BaseProtocol(object):
                                         **token_params)
             # Allow the credentials object to update its copy of the new
             # token, and give the application an opportunity to cache it
-            credentials.on_token_auto_refreshed(token)
+            self.credentials.on_token_auto_refreshed(token)
         session.auth = get_auth_instance(auth_type=OAUTH2, client=client)
 
         return session

--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -19,11 +19,11 @@ import requests.sessions
 import requests.utils
 from future.utils import with_metaclass, python_2_unicode_compatible
 from future.moves.queue import LifoQueue, Empty, Full
-from oauthlib.oauth2 import BackendApplicationClient
+from oauthlib.oauth2 import BackendApplicationClient, WebApplicationClient
 from requests_oauthlib import OAuth2Session
 from six import string_types
 
-from .credentials import OAuth2Credentials
+from .credentials import OAuth2AuthorizationCodeCredentials, OAuth2Credentials
 from .errors import TransportError, SessionPoolMinSizeReached
 from .properties import FreeBusyViewOptions, MailboxData, TimeWindow, TimeZone
 from .services import GetServerTimeZones, GetRoomLists, GetRooms, ResolveNames, GetUserAvailability, \
@@ -211,44 +211,116 @@ class BaseProtocol(object):
         del session
         return self.create_session()
 
-    def create_session(self):
-        if self.auth_type is None:
-            raise ValueError('Cannot create session without knowing the auth type')
-        if isinstance(self.credentials, OAuth2Credentials):
-            if self.auth_type != OAUTH2:
-                raise ValueError('Auth type must be %r for credentials type OAuth2Credentials' % OAUTH2)
+    def refresh_credentials(self, session):
+        # Credentials need to be refreshed, probably due to an OAuth
+        # access token expiring. If we've gotten here, it's because the
+        # application didn't provide an OAuth client secret, so we can't
+        # handle token refreshing for it.
+        with self.credentials.lock:
+            if hash(self.credentials) == self.credentials_hash:
+                # Credentials have not been refreshed by another thread:
+                # they're the same as the session was created with. If
+                # this isn't the case, we can just go ahead with a new
+                # session using the already-updated credentials.
+                self.credentials.refresh()
+        return self.renew_session(session)
 
-            token_url = 'https://login.microsoftonline.com/%s/oauth2/v2.0/token' % self.credentials.tenant_id
-            scope = ['https://outlook.office365.com/.default']
-            client = BackendApplicationClient(client_id=self.credentials.client_id)
-            session = self.raw_session(client)
-            # Fetch the token explicitly -- it doesn't occur implicitly
-            session.fetch_token(token_url=token_url, client_id=self.credentials.client_id,
-                                client_secret=self.credentials.client_secret, scope=scope)
-            session.auth = get_auth_instance(auth_type=OAUTH2, client=client)
-        elif self.credentials:
-            if self.auth_type == NTLM and self.credentials.type == self.credentials.EMAIL:
-                username = '\\' + self.credentials.username
+    def create_session(self):
+        with self.credentials.lock:
+            if self.auth_type is None:
+                raise ValueError('Cannot create session without knowing the auth type')
+            if isinstance(self.credentials, OAuth2Credentials):
+                session = self.create_oauth2_session()
+            elif self.credentials:
+                if self.auth_type == NTLM and self.credentials.type == self.credentials.EMAIL:
+                    username = '\\' + self.credentials.username
+                else:
+                    username = self.credentials.username
+                session = self.raw_session()
+                session.auth = get_auth_instance(auth_type=self.auth_type, username=username,
+                                                 password=self.credentials.password)
             else:
-                username = self.credentials.username
-            session = self.raw_session()
-            session.auth = get_auth_instance(auth_type=self.auth_type, username=username,
-                                             password=self.credentials.password)
-        else:
-            if self.auth_type not in (GSSAPI, SSPI):
-                raise ValueError('Auth type %r requires credentials' % self.auth_type)
-            session = self.raw_session()
-            session.auth = get_auth_instance(auth_type=self.auth_type)
+                if self.auth_type not in (GSSAPI, SSPI):
+                    raise ValueError('Auth type %r requires credentials' % self.auth_type)
+                session = self.raw_session()
+                session.auth = get_auth_instance(auth_type=self.auth_type)
+            # Keep track of the credentials used to create this session. If
+            # and when we need to renew credentials (for example, refreshing
+            # an OAuth access token), this lets us easily determine whether
+            # the credentials have already been refreshed in another thread
+            # by the time this session tries.
+            session.credentials_hash = hash(self.credentials)
         # Add some extra info
         session.session_id = sum(map(ord, str(os.urandom(100))))  # Used for debugging messages in services
         session.protocol = self
         log.debug('Server %s: Created session %s', self.server, session.session_id)
         return session
 
+    def create_oauth2_session(self):
+        if self.auth_type != OAUTH2:
+            raise ValueError('Auth type must be %r for credentials type OAuth2Credentials' % OAUTH2)
+
+        has_token = False
+        scope = ['https://outlook.office365.com/.default']
+        session_params = {}
+        token_params = {}
+
+        if isinstance(self.credentials, OAuth2AuthorizationCodeCredentials):
+            # Ask for a refresh token
+            scope.append('offline_access')
+
+            # We don't know (or need) the Microsoft tenant ID. Use
+            # common/ to let Microsoft select the appropriate tenant
+            # for the provided authorization code or refresh token.
+            token_url = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+
+            client_params = {}
+            has_token = self.credentials.access_token is not None
+            if has_token:
+                session_params['token'] = self.credentials.access_token
+            elif self.credentials.authorization_code is not None:
+                token_params['code'] = self.credentials.authorization_code
+                self.credentials.authorization_code = None
+
+            if self.credentials.client_id is not None and self.credentials.client_secret is not None:
+                # If we're given a client ID and secret, we have enough
+                # to refresh access tokens ourselves. In other cases the
+                # session will raise TokenExpiredError and we'll need to
+                # ask the calling application to refresh the token (that
+                # covers cases where the caller doesn't have access to
+                # the client secret but is working with a service that
+                # can provide it refreshed tokens on a limited basis).
+                session_params = {
+                    **session_params,
+                    'auto_refresh_kwargs': {
+                        'client_id': self.credentials.client_id,
+                        'client_secret': self.credentials.client_secret,
+                    },
+                    'auto_refresh_url': token_url,
+                    'token_updater': self.credentials.on_token_auto_refreshed,
+                }
+            client = WebApplicationClient(self.credentials.client_id, **client_params)
+        else:
+            token_url = 'https://login.microsoftonline.com/%s/oauth2/v2.0/token' % self.credentials.tenant_id
+            client = BackendApplicationClient(client_id=self.credentials.client_id)
+
+        session = self.raw_session(client, session_params)
+        if not has_token:
+            # Fetch the token explicitly -- it doesn't occur implicitly
+            token = session.fetch_token(token_url=token_url, client_id=self.credentials.client_id,
+                                        client_secret=self.credentials.client_secret, scope=scope,
+                                        **token_params)
+            # Allow the credentials object to update its copy of the new
+            # token, and give the application an opportunity to cache it
+            credentials.on_token_auto_refreshed(token)
+        session.auth = get_auth_instance(auth_type=OAUTH2, client=client)
+
+        return session
+
     @classmethod
-    def raw_session(cls, oauth2_client=None):
+    def raw_session(cls, oauth2_client=None, oauth2_session_params=None):
         if oauth2_client:
-            session = OAuth2Session(client=oauth2_client)
+            session = OAuth2Session(client=oauth2_client, **(oauth2_session_params or {}))
         else:
             session = requests.sessions.Session()
         session.headers.update(DEFAULT_HEADERS)

--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -21,6 +21,7 @@ from future.backports.misc import get_ident
 from future.moves.urllib.parse import urlparse
 from future.utils import PY2
 import isodate
+from oauthlib.oauth2 import TokenExpiredError
 from pygments import highlight
 from pygments.lexers.html import XmlLexer
 from pygments.formatters.terminal import TerminalFormatter
@@ -535,8 +536,8 @@ class DummyRequest(object):
 
 
 class DummyResponse(object):
-    def __init__(self, url, headers, request_headers, content=b''):
-        self.status_code = 503
+    def __init__(self, url, headers, request_headers, content=b'', status_code=503):
+        self.status_code = status_code
         self.url = url
         self.headers = headers
         self.content = content
@@ -696,6 +697,9 @@ Response data: %(xml_response)s
             except CONNECTION_ERRORS as e:
                 log.debug('Session %s thread %s: connection error POST\'ing to %s', session.session_id, thread_id, url)
                 r = DummyResponse(url=url, headers={'TimeoutException': e}, request_headers=headers)
+            except TokenExpiredError as e:
+                log.debug('Session %s thread %s: OAuth token expired; refreshing', session.session_id, thread_id)
+                r = DummyResponse(url=url, headers={'TokenExpiredError': e}, request_headers=headers, status_code=401)
             finally:
                 log_vals.update(
                     retry=retry,
@@ -709,6 +713,9 @@ Response data: %(xml_response)s
                     xml_response='[STREAMING]' if stream else r.content,
                 )
             log.debug(log_msg, log_vals)
+            if _need_new_credentials(response=r):
+                session = protocol.refresh_credentials(session)
+                continue
             if _may_retry_on_error(response=r, retry_policy=protocol.retry_policy, wait=wait):
                 log.info("Session %s thread %s: Connection error on URL %s (code %s). Cool down %s secs",
                          session.session_id, thread_id, r.url, r.status_code, wait)
@@ -776,6 +783,11 @@ def _may_retry_on_error(response, retry_policy, wait):
             or (response.status_code == 503):
         return True
     return False
+
+
+def _need_new_credentials(response):
+    return response.status_code == 401 \
+        and response.headers.get('TokenExpiredError')
 
 
 def _redirect_or_fail(response, redirects, allow_redirects):


### PR DESCRIPTION
Previous work to use OAuth added support for the client credentials
grant type, which can be useful for an internal application intended
only to be authorized to access one organization's data. However, it
doesn't work well for multitenant applications since there's no way to
guarantee that the redirect from authorization wasn't tampered with,
which could enable an attack involving changing the tenant ID before
completing the redirect.

That's precisely the problem the authorization code grant solves, so
this expands OAuth support to cover that grant type. This includes a
provision for a somewhat specific case where the calling application
isn't privy to the OAuth application ID and secret and instead relies
on another service to issue and refresh access tokens. In such cases,
applications can subclass OAuth2AuthorizationCodeCredentials and
implement refresh() to provide their own refresh logic.