### PR TITLE
Fix pagination item counting with max_items set

### DIFF
--- a/exchangelib/services/common.py
+++ b/exchangelib/services/common.py
@@ -442,9 +442,13 @@ class PagingEWSMixIn(EWSService):
                         raise MalformedResponseError('No %s elements in ResponseMessage (%s)' % (
                             self.element_container_name, xml_to_str(rootfolder)))
                     for elem in self._get_elements_in_container(container=container):
+                        if max_items and total_item_count >= max_items:
+                            # No need to continue. Break out of elements loop
+                            log.debug("'max_items' count reached (elements)")
+                            break
                         paging_info['item_count'] += 1
+                        total_item_count += 1
                         yield elem
-                    total_item_count += paging_info['item_count']
                     if max_items and total_item_count >= max_items:
                         # No need to continue. Break out of inner loop
                         log.debug("'max_items' count reached (inner)")
@@ -455,7 +459,10 @@ class PagingEWSMixIn(EWSService):
                 # Check sanity of paging offsets, but don't fail. When we are iterating huge collections that take a
                 # long time to complete, the collection may change while we are iterating. This can affect the
                 # 'next_offset' value and make it inconsistent with the number of already collected items.
-                if paging_info['next_offset'] != paging_info['item_count']:
+                # We don't worry about If breaking early due to having reached 'max_items'.
+                if paging_info['next_offset'] != paging_info['item_count'] and (
+                    not max_items or total_item_count < max_items
+                ):
                     log.warning('Unexpected next offset: %s -> %s. Maybe the server-side collection has changed?'
                                 % (paging_info['item_count'], paging_info['next_offset']))
             # Also break out of outer loop


### PR DESCRIPTION
Noticed odd behaviour when setting `max_items` on a query set in combination with `page_size`.

E.g. 
`page_size = 20`, `max_items = 100`, query on a single folder: returned **60** items.

I noticed the `total_item_count` was adding the `item_count` of each "folder" in the current batch of pages, which seems incorrect, as each page it would add what had already been added before. Eg.
1. `total_item_count = 20` (`item_count = 20`) **Fetched 20 items**
2. `total_item_count = 20 + 40 (60)` (`item_count = 40`) **Fetched 40 items**
3. `total_item_count = 60 + 60 (120)` (`item_count = 60`) **Fetched 60 items**
4. **Stop** as `total_item_count >= max_items`.

Then I also realised this was even worse with multiple folders as each of those counts would be added for each folder.

I'm proposing this pretty simple fix which instead of adding `item_count` to `total_item_count` it simply keeps count of items on it's own. On top of that I also suggest breaking out of the element by element loop once the `max_items` is reached as otherwise you'd get more than `max_items` (multiples of `page_count`).

It's possible I'm missing something, and I haven't tested this extensively, but thought it worth sending over a PR as it looks like a bug to me.