### PR TITLE
Ensure BaseFolder.glob() is case-insensitive (#736)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ some_folder.root  # Returns the root of the folder structure, at any level. Same
 some_folder.children  # A generator of child folders
 some_folder.absolute  # Returns the absolute path, as a string
 some_folder.walk()  # A generator returning all subfolders at arbitrary depth this level
-# Globbing uses the normal UNIX globbing syntax
+# Globbing uses the normal UNIX globbing syntax, but case-insensitive
 some_folder.glob('foo*')  # Return child folders matching the pattern
 some_folder.glob('*/foo')  # Return subfolders named 'foo' in any child folder
 some_folder.glob('**/foo')  # Return subfolders named 'foo' at any depth

--- a/exchangelib/folders/base.py
+++ b/exchangelib/folders/base.py
@@ -126,12 +126,16 @@ class BaseFolder(RegisterMixIn, SearchableMixIn):
         elif head == '**':
             # Match anything here or in any subfolder at arbitrary depth
             for c in self.walk():
-                if fnmatch(c.name, tail or '*'):
+                # fnmatch() may be case-sensitive depending on operating system:
+                # force a case-insensitive match since case appears not to
+                # matter for folders in Exchange
+                if fnmatch(c.name.lower(), (tail or '*').lower()):
                     yield c
         else:
             # Regular pattern
             for c in self.children:
-                if not fnmatch(c.name, head):
+                # See note above on fnmatch() case-sensitivity
+                if not fnmatch(c.name.lower(), head.lower()):
                     continue
                 if tail is None:
                     yield c

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -274,6 +274,7 @@ class FolderTest(EWSTest):
     def test_glob(self):
         self.assertGreaterEqual(len(list(self.account.root.glob('*'))), 5)
         self.assertEqual(len(list(self.account.contacts.glob('GAL*'))), 1)
+        self.assertEqual(len(list(self.account.contacts.glob('gal*'))), 1)  # Test case-insensitivity
         self.assertGreaterEqual(len(list(self.account.contacts.glob('/'))), 5)
         self.assertGreaterEqual(len(list(self.account.contacts.glob('../*'))), 5)
         self.assertEqual(len(list(self.account.root.glob('**/%s' % self.account.contacts.name))), 1)


### PR DESCRIPTION
Exchange folder names appear to be case-insensitive (although there
isn't documentation defining that with certainty), but the arguments to
`BaseFolder.glob()` may be interpreted in a case-sensitive way depending
on the operating system.

`glob()` uses `fnmatch.fnmatch()`, which passes arguments through
`os.path.normcase()`, which behaves differently on Windows compared to
other operating systems.

This forces a case-insensitive comparison to match Exchange. Fixes #736 