### PR TITLE
Add methods to get logger in library and set level

### DIFF
--- a/exchangelib/api.py
+++ b/exchangelib/api.py
@@ -1,0 +1,46 @@
+import importlib
+import logging
+import pkgutil
+
+import exchangelib
+
+
+def _import_submodules(package, recursive=True):
+    """ Import all submodules of a module, recursively, including subpackages
+    :param package: package (name or actual module)
+    :type package: str | module
+    :rtype: dict[str, types.ModuleType]
+    https://stackoverflow.com/questions/3365740/how-to-import-all-submodules
+    """
+    if isinstance(package, str):
+        package = importlib.import_module(package)
+    results = {}
+    for loader, name, is_pkg in pkgutil.walk_packages(package.__path__):
+        full_name = package.__name__ + '.' + name
+        results[full_name] = importlib.import_module(full_name)
+        if recursive and is_pkg:
+            results.update(_import_submodules(full_name))
+    return results
+
+__LOGGERS = None
+
+@property
+def loggers():
+    """Return exchangelib loggers, lazily evaluated"""
+    if __LOGGERS is None:
+        __LIB_LOGGERS = []
+
+        results = _import_submodules(exchangelib)
+        for r in results:
+            try:
+                lg = eval("{}.log".format(r))
+                if isinstance(lg,logging.Logger):
+                    __LOGGERS.append(lg)
+            except AttributeError:
+                pass
+    return __LOGGERS
+
+def setLevel(level:int)->None:
+    """Set logging for all modules in exchangelib"""
+    for logger in loggers:
+        logger.setLevel(level)

--- a/tests/test_api_logging.py
+++ b/tests/test_api_logging.py
@@ -1,0 +1,95 @@
+from unittest import TestCase
+
+import requests_mock
+
+from exchangelib import Version, logging
+from exchangelib.errors import TransportError
+from exchangelib.version import EXCHANGE_2007, Build
+from exchangelib.util import to_xml
+
+from .common import TimedTestCase
+
+
+class LoggingTest(TestCase):
+    def test_logging(self):
+        loggers = logging.loggers
+        for lg in loggers:
+            self.assertIsInstance(lg,logging)
+
+
+    def test_default_api_version(self):
+        # Test that a version gets a reasonable api_version value if we don't set one explicitly
+        version = Version(build=Build(15, 1, 2, 3))
+        self.assertEqual(version.api_version, 'Exchange2016')
+
+    @requests_mock.mock()  # Just to make sure we don't make any requests
+    def test_from_response(self, m):
+        # Test fallback to suggested api_version value when there is a version mismatch and response version is fishy
+        version = Version.from_soap_header(
+            'Exchange2007',
+            to_xml(b'''\
+<s:Header>
+    <h:ServerVersionInfo
+        MajorBuildNumber="845" MajorVersion="15" MinorBuildNumber="22" MinorVersion="1" Version="V2016_10_10"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types"/>
+</s:Header>''')
+        )
+        self.assertEqual(version.api_version, EXCHANGE_2007.api_version())
+        self.assertEqual(version.api_version, 'Exchange2007')
+        self.assertEqual(version.build, Build(15, 1, 845, 22))
+
+        # Test that override the suggested version if the response version is not fishy
+        version = Version.from_soap_header(
+            'Exchange2013',
+            to_xml(b'''\
+<s:Header>
+    <h:ServerVersionInfo
+        MajorBuildNumber="845" MajorVersion="15" MinorBuildNumber="22" MinorVersion="1" Version="HELLO_FROM_EXCHANGELIB"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types"/>
+</s:Header>''')
+        )
+        self.assertEqual(version.api_version, 'HELLO_FROM_EXCHANGELIB')
+
+        # Test that we override the suggested version with the version deduced from the build number if a version is not
+        # present in the response
+        version = Version.from_soap_header(
+            'Exchange2013',
+            to_xml(b'''\
+<s:Header>
+    <h:ServerVersionInfo
+        MajorBuildNumber="845" MajorVersion="15" MinorBuildNumber="22" MinorVersion="1"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types"/>
+</s:Header>''')
+        )
+        self.assertEqual(version.api_version, 'Exchange2016')
+
+        # Test that we use the version deduced from the build number when a version is not present in the response and
+        # there was no suggested version.
+        version = Version.from_soap_header(
+            None,
+            to_xml(b'''\
+<s:Header>
+    <h:ServerVersionInfo
+        MajorBuildNumber="845" MajorVersion="15" MinorBuildNumber="22" MinorVersion="1"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types"/>
+</s:Header>''')
+        )
+        self.assertEqual(version.api_version, 'Exchange2016')
+
+        # Test various parse failures
+        with self.assertRaises(TransportError):
+            Version.from_soap_header(
+                'Exchange2013',
+                to_xml(b'''\
+<s:Header>
+</s:Header>''')
+            )
+        with self.assertRaises(TransportError):
+            Version.from_soap_header(
+                'Exchange2013',
+                to_xml(b'''\
+<s:Header>
+    <h:ServerVersionInfo MajorBuildNumber="845" MajorVersion="15" Version="V2016_10_10"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types"/>
+</s:Header>''')
+            )


### PR DESCRIPTION
I thought it would be useful for my own purposes to have a list of the loggers within exchangelib, and to be able to be able to set their level within having to changed the root logger level.

Offering the code in the event you think it would be useful for others.