### PR TITLE
Add System1 folder class to known folders

### DIFF
--- a/exchangelib/folders/known_folders.py
+++ b/exchangelib/folders/known_folders.py
@@ -618,6 +618,14 @@ class System(NonDeleteableFolderMixin, Folder):
     __slots__ = tuple()
 
 
+class System1(NonDeleteableFolderMixin, Folder):
+    LOCALIZED_NAMES = {
+        None: ('System1',),
+    }
+    get_folder_allowed = False
+    __slots__ = tuple()
+
+
 class TemporarySaves(NonDeleteableFolderMixin, Folder):
     LOCALIZED_NAMES = {
         None: ('TemporarySaves',),
@@ -671,6 +679,7 @@ NON_DELETEABLE_FOLDERS = [
     SmsAndChatsSync,
     SpoolerQueue,
     System,
+    System1,
     TemporarySaves,
     Views,
     WorkingSet,


### PR DESCRIPTION
Fix for #862 : a Microsoft proprietary folder called System1 in the top level root is not accessible via get requests and attempting to request it causes batch processing to stop. This adds a System1 class to the list of known folders to prevent get requests from being placed while walking the top level root.