### PR TITLE
Pin version tzlocal==2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'requests_ntlm>=0.2.0',
         'requests_oauthlib',
         'tzdata',
-        'tzlocal',
+        'tzlocal==2.1',
     ],
     extras_require={
         'kerberos': ['requests_gssapi'],


### PR DESCRIPTION
Hello,

There has been an API change in version 3.0 of tzlocal library (please check the [changelog](https://github.com/regebro/tzlocal/blob/master/CHANGES.txt) and [readme](https://github.com/regebro/tzlocal/blob/master/README.rst)). Current version of exchangelib is not compatible with tzlocal 3.0. I'm getting following error

```python
AttributeError: 'backports.zoneinfo.ZoneInfo' object has no attribute 'zone'
```

<details>

```python
/usr/local/lib/python3.8/site-packages/exchangelib/account.py in __init__(self, primary_smtp_address, fullname, access_type, autodiscover, credentials, config, locale, default_timezone)
     91         try:
---> 92             self.default_timezone = default_timezone or EWSTimeZone.localzone()
     93         except (ValueError, UnknownTimeZone) as e:

/usr/local/lib/python3.8/site-packages/exchangelib/ewsdatetime.py in localzone(cls)
    263             raise UnknownTimeZone("Failed to guess local timezone")
--> 264         return cls.from_pytz(tz)
    265 

/usr/local/lib/python3.8/site-packages/exchangelib/ewsdatetime.py in from_pytz(cls, tz)
    243         try:
--> 244             self_cls.ms_id = cls.PYTZ_TO_MS_MAP[tz.zone][0]
    245         except KeyError:

AttributeError: 'backports.zoneinfo.ZoneInfo' object has no attribute 'zone'
```
</details>

As a quick fix I pinned the version of tzlocal to 2.1.