### PR TITLE
Fixed types for Contact.manager_mailbox and Contact.direct_reports

### DIFF
--- a/docs/exchangelib/index.html
+++ b/docs/exchangelib/index.html
@@ -4552,9 +4552,9 @@ we use folder.account.</p></div>
     ms_exchange_certificate = Base64Field(field_uri=&#39;contacts:MSExchangeCertificate&#39;, supported_from=EXCHANGE_2010_SP2,
                                           is_read_only=True)
     directory_id = TextField(field_uri=&#39;contacts:DirectoryId&#39;, supported_from=EXCHANGE_2010_SP2, is_read_only=True)
-    manager_mailbox = CharField(field_uri=&#39;contacts:ManagerMailbox&#39;, supported_from=EXCHANGE_2010_SP2,
+    manager_mailbox = MailboxField(field_uri=&#39;contacts:ManagerMailbox&#39;, supported_from=EXCHANGE_2010_SP2,
                                 is_read_only=True)
-    direct_reports = CharField(field_uri=&#39;contacts:DirectReports&#39;, supported_from=EXCHANGE_2010_SP2,
+    direct_reports = MailboxListField(field_uri=&#39;contacts:DirectReports&#39;, supported_from=EXCHANGE_2010_SP2,
                                is_read_only=True)</code></pre>
 </details>
 <h3>Ancestors</h3>

--- a/docs/exchangelib/items/contact.html
+++ b/docs/exchangelib/items/contact.html
@@ -110,9 +110,9 @@ class Contact(Item):
     ms_exchange_certificate = Base64Field(field_uri=&#39;contacts:MSExchangeCertificate&#39;, supported_from=EXCHANGE_2010_SP2,
                                           is_read_only=True)
     directory_id = TextField(field_uri=&#39;contacts:DirectoryId&#39;, supported_from=EXCHANGE_2010_SP2, is_read_only=True)
-    manager_mailbox = CharField(field_uri=&#39;contacts:ManagerMailbox&#39;, supported_from=EXCHANGE_2010_SP2,
+    manager_mailbox = MailboxField(field_uri=&#39;contacts:ManagerMailbox&#39;, supported_from=EXCHANGE_2010_SP2,
                                 is_read_only=True)
-    direct_reports = CharField(field_uri=&#39;contacts:DirectReports&#39;, supported_from=EXCHANGE_2010_SP2,
+    direct_reports = MailboxListField(field_uri=&#39;contacts:DirectReports&#39;, supported_from=EXCHANGE_2010_SP2,
                                is_read_only=True)
 
 
@@ -326,9 +326,9 @@ we use folder.account.</p></div>
     ms_exchange_certificate = Base64Field(field_uri=&#39;contacts:MSExchangeCertificate&#39;, supported_from=EXCHANGE_2010_SP2,
                                           is_read_only=True)
     directory_id = TextField(field_uri=&#39;contacts:DirectoryId&#39;, supported_from=EXCHANGE_2010_SP2, is_read_only=True)
-    manager_mailbox = CharField(field_uri=&#39;contacts:ManagerMailbox&#39;, supported_from=EXCHANGE_2010_SP2,
+    manager_mailbox = MailboxField(field_uri=&#39;contacts:ManagerMailbox&#39;, supported_from=EXCHANGE_2010_SP2,
                                 is_read_only=True)
-    direct_reports = CharField(field_uri=&#39;contacts:DirectReports&#39;, supported_from=EXCHANGE_2010_SP2,
+    direct_reports = MailboxListField(field_uri=&#39;contacts:DirectReports&#39;, supported_from=EXCHANGE_2010_SP2,
                                is_read_only=True)</code></pre>
 </details>
 <h3>Ancestors</h3>

--- a/docs/exchangelib/items/index.html
+++ b/docs/exchangelib/items/index.html
@@ -1154,9 +1154,9 @@ we use folder.account.</p></div>
     ms_exchange_certificate = Base64Field(field_uri=&#39;contacts:MSExchangeCertificate&#39;, supported_from=EXCHANGE_2010_SP2,
                                           is_read_only=True)
     directory_id = TextField(field_uri=&#39;contacts:DirectoryId&#39;, supported_from=EXCHANGE_2010_SP2, is_read_only=True)
-    manager_mailbox = CharField(field_uri=&#39;contacts:ManagerMailbox&#39;, supported_from=EXCHANGE_2010_SP2,
+    manager_mailbox = MailboxField(field_uri=&#39;contacts:ManagerMailbox&#39;, supported_from=EXCHANGE_2010_SP2,
                                 is_read_only=True)
-    direct_reports = CharField(field_uri=&#39;contacts:DirectReports&#39;, supported_from=EXCHANGE_2010_SP2,
+    direct_reports = MailboxListField(field_uri=&#39;contacts:DirectReports&#39;, supported_from=EXCHANGE_2010_SP2,
                                is_read_only=True)</code></pre>
 </details>
 <h3>Ancestors</h3>

--- a/exchangelib/items/contact.py
+++ b/exchangelib/items/contact.py
@@ -6,7 +6,8 @@ from ..fields import BooleanField, Base64Field, TextField, ChoiceField, URIField
     PhoneNumberField, EmailAddressesField, PhysicalAddressField, Choice, MemberListField, CharField, TextListField, \
     EmailAddressField, IdElementField, EWSElementField, DateTimeField, EWSElementListField, \
     BodyContentAttributedValueField, StringAttributedValueField, PhoneNumberAttributedValueField, \
-    PersonaPhoneNumberField, EmailAddressAttributedValueField, PostalAddressAttributedValueField
+    PersonaPhoneNumberField, EmailAddressAttributedValueField, PostalAddressAttributedValueField, MailboxField, \
+    MailboxListField
 from ..properties import PersonaId, IdChangeKeyMixIn, CompleteName, Attribution, EmailAddress, Address, FolderId
 from ..util import TNS
 from ..version import EXCHANGE_2010, EXCHANGE_2010_SP2
@@ -82,9 +83,9 @@ class Contact(Item):
     ms_exchange_certificate = Base64Field(field_uri='contacts:MSExchangeCertificate', supported_from=EXCHANGE_2010_SP2,
                                           is_read_only=True)
     directory_id = TextField(field_uri='contacts:DirectoryId', supported_from=EXCHANGE_2010_SP2, is_read_only=True)
-    manager_mailbox = CharField(field_uri='contacts:ManagerMailbox', supported_from=EXCHANGE_2010_SP2,
+    manager_mailbox = MailboxField(field_uri='contacts:ManagerMailbox', supported_from=EXCHANGE_2010_SP2,
                                 is_read_only=True)
-    direct_reports = CharField(field_uri='contacts:DirectReports', supported_from=EXCHANGE_2010_SP2,
+    direct_reports = MailboxListField(field_uri='contacts:DirectReports', supported_from=EXCHANGE_2010_SP2,
                                is_read_only=True)
 
 


### PR DESCRIPTION
Hi!

I've tried to get manager and direct reports information from our corporate Exchange, but was unable to do so. Looks like `manager_mailbox` and `direct_reports` must be of types `MailboxField` and `MailboxListField` for this to work.