### PR TITLE
Adding Lambda compatibility

### DIFF
--- a/exchangelib/folders/roots.py
+++ b/exchangelib/folders/roots.py
@@ -19,7 +19,7 @@ class LambdaLock():
     """Memory lock placeholder for execution on AWS Lambda.
     Required due to lack of /dev/shm in Lambda and hence errors when trying to lock the memory.
     """
-    
+
     def __init__(self):
         return None
 


### PR DESCRIPTION
Related to #997, added LambdaLock class to act as a placeholder for multiprocessing.Lock when executing on AWS Lambda.

Without this change the multiprocessing.Lock function results in "OSError: [Errno 38] Function not implemented" due to the lack of the shared memory resource /dev/shm. With this change, the AWS_EXECUTION_ENV environment variable is queried and, if found, the LambdaLock is used instead, essentially leaving the memory unlocked when checking folders.

As the memory lock was implemented 620ec82 to address concurrency issues, this proposed change may cause such issues to arise again on Lambda, but is preferable to using outdated versions predating this change.