### PR TITLE
Support datetime.timezone to EWSTimeZone conversion

### DIFF
--- a/exchangelib/ewsdatetime.py
+++ b/exchangelib/ewsdatetime.py
@@ -251,6 +251,11 @@ class EWSTimeZone(zoneinfo.ZoneInfo):
         return cls(tz.zone)
 
     @classmethod
+    def from_datetime(cls, tz):
+        """Convert from a standard library `datetime.timezone` instance."""
+        return cls(tz.tzname(None))
+
+    @classmethod
     def from_dateutil(cls, tz):
         # Objects returned by dateutil.tz.tzlocal() and dateutil.tz.gettz() are not supported. They
         # don't contain enough information to reliably match them with a CLDR timezone.
@@ -272,6 +277,7 @@ class EWSTimeZone(zoneinfo.ZoneInfo):
             return {
                 cls.__module__.split('.')[0]: lambda z: z,
                 'backports': cls.from_zoneinfo,
+                'datetime': cls.from_datetime,
                 'dateutil': cls.from_dateutil,
                 'pytz': cls.from_pytz,
                 'zoneinfo': cls.from_zoneinfo,

--- a/tests/test_ewsdatetime.py
+++ b/tests/test_ewsdatetime.py
@@ -102,6 +102,10 @@ class EWSDateTimeTest(TimedTestCase):
             EWSTimeZone('UTC'),
             EWSTimeZone.from_timezone(dateutil.tz.UTC)
         )
+        self.assertEqual(
+            EWSTimeZone('UTC'),
+            EWSTimeZone.from_timezone(datetime.timezone.utc)
+        )
 
     def test_localize(self):
         # Test some corner cases around DST


### PR DESCRIPTION
The python stdlib contains a timezone implementation at `datetime.timezone`. It would be convenient to support converting this class into `EWSTimeZone`, to support the shorthand `datetime.timezone.utc`.

This PR adds a failing test case, and uses `tzname(None)` to convert the timezone into it's IANA timezone string:
- Documentation: https://docs.python.org/3/library/datetime.html#datetime.timezone.tzname
- Implementation: https://github.com/python/cpython/blob/401272e6e660445d6556d5cd4db88ed4267a50b3/Lib/datetime.py#L2255