### PR TITLE
Don't interpret Period identifiers. Fixes #1058

### DIFF
--- a/exchangelib/errors.py
+++ b/exchangelib/errors.py
@@ -120,10 +120,6 @@ class UnknownTimeZone(EWSError):
     pass
 
 
-class TimezoneDefinitionInvalidForYear(EWSError):
-    pass
-
-
 class SessionPoolMinSizeReached(EWSError):
     pass
 

--- a/exchangelib/properties.py
+++ b/exchangelib/properties.py
@@ -1864,18 +1864,6 @@ class Period(EWSElement):
     name = CharField(field_uri="Name", is_attribute=True)
     bias = TimeDeltaField(field_uri="Bias", is_attribute=True)
 
-    def _split_id(self):
-        to_year, to_type = self.id.rsplit("/", 1)[1].split("-")
-        return int(to_year), to_type
-
-    @property
-    def year(self):
-        return self._split_id()[0]
-
-    @property
-    def type(self):
-        return self._split_id()[1]
-
     @property
     def bias_in_minutes(self):
         return int(self.bias.total_seconds()) // 60  # Convert to minutes
@@ -1906,17 +1894,14 @@ class TimeZoneDefinition(EWSElement):
     def from_xml(cls, elem, account):
         return super().from_xml(elem, account)
 
-    def _get_standard_period(self, for_year):
-        # Look through periods and pick a relevant period according to the 'for_year' value
+    def _get_standard_period(self, transitions_group):
+        # Find the first standard period referenced from transitions_group
         valid_period = None
-        for period in sorted(self.periods, key=lambda p: (p.year, p.type)):
-            if period.year > for_year:
+        standard_periods_map = {p.id: p for p in self.periods if p.name == "Standard"}
+        for transition in transitions_group.transitions:
+            valid_period = standard_periods_map.get(transition.to)
+            if valid_period:
                 break
-            if period.type != "Standard":
-                continue
-            valid_period = period
-        if valid_period is None:
-            raise TimezoneDefinitionInvalidForYear(f"Year {for_year} not included in periods {self.periods}")
         return valid_period
 
     def _get_transitions_group(self, for_year):
@@ -1939,7 +1924,9 @@ class TimeZoneDefinition(EWSElement):
         if not 0 <= len(transitions_group.transitions) <= 2:
             raise ValueError(f"Expected 0-2 transitions in transitions group {transitions_group}")
 
-        standard_period = self._get_standard_period(for_year)
+        standard_period = self._get_standard_period(transitions_group)
+        if standard_period is None:
+            raise TimezoneDefinitionInvalidForYear(f"Period {for_year} not included in periods {self.periods}")
         periods_map = {p.id: p for p in self.periods}
         standard_time, daylight_time = None, None
         if len(transitions_group.transitions) == 1:

--- a/exchangelib/properties.py
+++ b/exchangelib/properties.py
@@ -7,7 +7,7 @@ import struct
 from inspect import getmro
 from threading import Lock
 
-from .errors import InvalidTypeError, TimezoneDefinitionInvalidForYear
+from .errors import InvalidTypeError
 from .fields import (
     WEEKDAY_NAMES,
     AssociatedCalendarItemIdField,
@@ -1894,14 +1894,15 @@ class TimeZoneDefinition(EWSElement):
     def from_xml(cls, elem, account):
         return super().from_xml(elem, account)
 
-    def _get_standard_period(self, transitions_group, for_year):
+    def _get_standard_period(self, transitions_group):
         # Find the first standard period referenced from transitions_group
         standard_periods_map = {p.id: p for p in self.periods if p.name == "Standard"}
-        standard_transitions = (t for t in transitions_group.transitions if t.to in standard_periods_map)
-        try:
-            return standard_periods_map[next(standard_transitions).to]
-        except StopIteration:
-            raise TimezoneDefinitionInvalidForYear(f"Year {for_year} not included in periods {self.periods}")
+        for transition in transitions_group.transitions:
+            try:
+                return standard_periods_map[transition.to]
+            except KeyError:
+                continue
+        raise ValueError(f"No standard period matching transition reference {transition.to}")
 
     def _get_transitions_group(self, for_year):
         # Look through the transitions, and pick the relevant transition group according to the 'for_year' value
@@ -1923,7 +1924,7 @@ class TimeZoneDefinition(EWSElement):
         if not 0 <= len(transitions_group.transitions) <= 2:
             raise ValueError(f"Expected 0-2 transitions in transitions group {transitions_group}")
 
-        standard_period = self._get_standard_period(transitions_group, for_year)
+        standard_period = self._get_standard_period(transitions_group)
         periods_map = {p.id: p for p in self.periods}
         standard_time, daylight_time = None, None
         if len(transitions_group.transitions) == 1:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -33,14 +33,17 @@ from exchangelib.properties import (
     ID_FORMATS,
     AlternateId,
     DLMailbox,
+    DaylightTime,
     FailedMailbox,
     FreeBusyView,
     FreeBusyViewOptions,
     ItemId,
     Mailbox,
     MailboxData,
+    Period,
     RoomList,
     SearchableMailbox,
+    StandardTime,
     TimeZone,
 )
 from exchangelib.protocol import BaseProtocol, FailFast, FaultTolerance, NoVerifyHTTPAdapter, Protocol
@@ -49,6 +52,7 @@ from exchangelib.services import (
     GetRoomLists,
     GetRooms,
     GetSearchableMailboxes,
+    GetServerTimeZones,
     ResolveNames,
     SetUserOofSettings,
 )
@@ -264,7 +268,78 @@ EWS auth: NTLM""",
                 self.assertEqual(tz.bias, tz_definition.get_std_and_dst(for_year=2018)[2].bias_in_minutes)
             except TimezoneDefinitionInvalidForYear:
                 pass
-
+    
+    def test_get_timezones_parsing(self):
+        # Test static XML since it's non-standard
+        xml = b"""\
+<?xml version='1.0' encoding='utf-8'?>
+<soap:Envelope
+    xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Header xmlns="http://schemas.xmlsoap.org/soap/envelope/">
+    <ServerVersionInfo xmlns="http://schemas.microsoft.com/exchange/services/2006/types" MajorVersion="14" MinorVersion="2" MajorBuildNumber="390" MinorBuildNumber="3" Version="Exchange2010_SP2"/>
+  </Header>
+  <soap:Body>
+    <m:GetServerTimeZonesResponse
+    xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+    xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages">
+      <m:ResponseMessages>
+        <m:GetServerTimeZonesResponseMessage ResponseClass="Success">
+          <m:ResponseCode>NoError</m:ResponseCode>
+          <m:TimeZoneDefinitions>
+            <t:TimeZoneDefinition Id="W. Europe Standard Time" Name="(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna">
+              <t:Periods>
+                <t:Period Bias="-PT60M" Name="Standard" Id="std"/>
+                <t:Period Bias="-PT120M" Name="Daylight" Id="dlt"/>
+              </t:Periods>
+              <t:TransitionsGroups>
+                <t:TransitionsGroup Id="0">
+                  <t:RecurringDayTransition>
+                    <t:To Kind="Period">std</t:To>
+                    <t:TimeOffset>PT180M</t:TimeOffset>
+                    <t:Month>10</t:Month>
+                    <t:DayOfWeek>Sunday</t:DayOfWeek>
+                    <t:Occurrence>-1</t:Occurrence>
+                  </t:RecurringDayTransition>
+                  <t:RecurringDayTransition>
+                    <t:To Kind="Period">dlt</t:To>
+                    <t:TimeOffset>PT120M</t:TimeOffset>
+                    <t:Month>3</t:Month>
+                    <t:DayOfWeek>Sunday</t:DayOfWeek>
+                    <t:Occurrence>-1</t:Occurrence>
+                  </t:RecurringDayTransition>
+                </t:TransitionsGroup>
+              </t:TransitionsGroups>
+              <t:Transitions>
+                <t:Transition>
+                  <t:To Kind="Group">0</t:To>
+                </t:Transition>
+              </t:Transitions>
+            </t:TimeZoneDefinition>
+          </m:TimeZoneDefinitions>
+        </m:GetServerTimeZonesResponseMessage>
+      </m:ResponseMessages>
+    </m:GetServerTimeZonesResponse>
+  </soap:Body>
+</soap:Envelope>"""
+        ws = GetServerTimeZones(self.account.protocol)
+        timezones = list(ws.parse(xml))
+        self.assertEqual(1, len(timezones))
+        (standard_transition, daylight_transition, standard_period) = timezones[0].get_std_and_dst(2022)
+        self.assertEqual(
+            standard_transition,
+            StandardTime(bias=0, time=datetime.time(hour=3), occurrence=5, iso_month=10, weekday=7),
+        )
+        self.assertEqual(
+            daylight_transition,
+            DaylightTime(bias=-60, time=datetime.time(hour=2), occurrence=5, iso_month=3, weekday=7),
+        )
+        self.assertEqual(
+            standard_period,
+            Period(id="std", name="Standard", bias=datetime.timedelta(minutes=-60)),
+        )
+        
     def test_get_free_busy_info(self):
         tz = self.account.default_timezone
         server_timezones = list(self.account.protocol.get_timezones(return_full_timezone_data=True))

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -24,7 +24,6 @@ from exchangelib.errors import (
     RateLimitError,
     SessionPoolMaxSizeReached,
     SessionPoolMinSizeReached,
-    TimezoneDefinitionInvalidForYear,
     TransportError,
 )
 from exchangelib.items import SEARCH_SCOPE_CHOICES, CalendarItem
@@ -266,7 +265,7 @@ EWS auth: NTLM""",
                     for_year=2018,
                 )
                 self.assertEqual(tz.bias, tz_definition.get_std_and_dst(for_year=2018)[2].bias_in_minutes)
-            except TimezoneDefinitionInvalidForYear:
+            except ValueError:
                 pass
     
     def test_get_timezones_parsing(self):


### PR DESCRIPTION
Instead find the correct period by finding the first Standard Period
referenced from the appropriate TransitionsGroup for the requested year.