### PR TITLE
Make exception hashable

### DIFF
--- a/exchangelib/errors.py
+++ b/exchangelib/errors.py
@@ -45,6 +45,9 @@ class EWSError(Exception):
     def __eq__(self, other):
         return repr(self) == repr(other)
 
+    def __hash__(self):
+        return hash(str(self))
+
 
 # Warnings
 class EWSWarning(EWSError):


### PR DESCRIPTION
Hello! Using the library I received an unexpected behavior from exception. 

`TypeError: unhashable type: ErrorNonExistentMailbox(The SMTP address has no mailbox associated with it.)`


I use rollbar for error notification. Rollbar in one of its functions goes through all the exceptions and stacks them into a set. 
```
def _walk_trace_chain(cls, exc, trace):
    trace_chain = [_trace_data(cls, exc, trace)]

    seen_exceptions = {exc}

    while True:
        exc = getattr(exc, '__cause__', None) or getattr(exc, '__context__', None)
        if not exc:
            break
        trace_chain.append(_trace_data(type(exc), exc, getattr(exc, '__traceback__', None)))
        if exc in seen_exceptions:
            break
        seen_exceptions.add(exc)

    return trace_chain
```


Consequently rollbar can't handle an exception exchangelib 

I don't know if you had a reason to make the exception unhashable, so I created this pr.
