### PR TITLE
Update discovery.py

### DIFF
--- a/exchangelib/autodiscover/discovery.py
+++ b/exchangelib/autodiscover/discovery.py
@@ -1,8 +1,8 @@
 import logging
 from urllib.parse import urlparse
 
-import dns.name
-import dns.resolver
+from dns.name import EmptyLabel
+from dns.resolver import LifetimeTimeout, NXDOMAIN, NoAnswer, NoNameservers, Resolver
 from cached_property import threaded_cached_property
 
 from ..configuration import Configuration
@@ -16,11 +16,11 @@ from .protocol import AutodiscoverProtocol
 log = logging.getLogger(__name__)
 
 DNS_LOOKUP_ERRORS = (
-    dns.name.EmptyLabel,
-    dns.resolver.LifetimeTimeout,
-    dns.resolver.NXDOMAIN,
-    dns.resolver.NoAnswer,
-    dns.resolver.NoNameservers,
+    EmptyLabel,
+    LifetimeTimeout,
+    NXDOMAIN,
+    NoAnswer,
+    NoNameservers,
 )
 
 
@@ -152,7 +152,7 @@ class Autodiscovery:
 
     @threaded_cached_property
     def resolver(self):
-        resolver = dns.resolver.Resolver(**self.DNS_RESOLVER_KWARGS)
+        resolver = Resolver(**self.DNS_RESOLVER_KWARGS)
         for k, v in self.DNS_RESOLVER_ATTRS.items():
             setattr(resolver, k, v)
         return resolver


### PR DESCRIPTION
Allow the initialization of the DNS_LOOKUP_ERROR variable to work without error.

In my use case importing:

```from exchangelib import Folder```

raised the exception :

```
File "/root/.pex/unzipped_pexes/0bf8be61a4ebad23d549d3f586c2e0a8702a896d/fast_api/routers/connecteurMail/__init__.py", line 10, in <module>
    from exchangelib import Folder
  File "/root/.pex/installed_wheels/9c88853ab554b6cb969a214da5615182d3ce47dc7bd99beb3dc0e805ab8af438/exchangelib-5.2.1-py3-none-any.whl/exchangelib/__init__.py", line 1, in <module>
    from .account import Account, Identity
  File "/root/.pex/installed_wheels/9c88853ab554b6cb969a214da5615182d3ce47dc7bd99beb3dc0e805ab8af438/exchangelib-5.2.1-py3-none-any.whl/exchangelib/account.py", line 6, in <module>
    from .autodiscover import Autodiscovery
  File "/root/.pex/installed_wheels/9c88853ab554b6cb969a214da5615182d3ce47dc7bd99beb3dc0e805ab8af438/exchangelib-5.2.1-py3-none-any.whl/exchangelib/autodiscover/__init__.py", line 2, in <module>
    from .discovery import Autodiscovery, discover
  File "/root/.pex/installed_wheels/9c88853ab554b6cb969a214da5615182d3ce47dc7bd99beb3dc0e805ab8af438/exchangelib-5.2.1-py3-none-any.whl/exchangelib/autodiscover/discovery.py", line 20, in <module>
    dns.resolver.LifetimeTimeout,
    ^^^^^^^^^^^^
AttributeError: module 'dns' has no attribute 'resolver'
```