### PR TITLE
Add configuration value to allow unverified connection

### DIFF
--- a/exchangelib/configuration.py
+++ b/exchangelib/configuration.py
@@ -38,6 +38,9 @@ class Configuration:
 
     'max_connections' defines the max number of connections allowed for this server. This may be restricted by
     policies on the Exchange server.
+
+    'verify' defines whether any SSL certificates in the connection to the server will be verified. Defaults to
+    True. Only change deviate from this if really necessary as this opens you up to man-in-the-middle-type attacks.
     """
 
     def __init__(
@@ -49,6 +52,7 @@ class Configuration:
         version=None,
         retry_policy=None,
         max_connections=None,
+        verify=True,
     ):
         if not isinstance(credentials, (BaseCredentials, type(None))):
             raise InvalidTypeError("credentials", credentials, BaseCredentials)
@@ -69,6 +73,8 @@ class Configuration:
             raise InvalidTypeError("retry_policy", retry_policy, RetryPolicy)
         if not isinstance(max_connections, (int, type(None))):
             raise InvalidTypeError("max_connections", max_connections, int)
+        if not isinstance(verify, bool):
+            raise InvalidTypeError("verify", verify, bool)
         self._credentials = credentials
         if server:
             self.service_endpoint = f"https://{server}/EWS/Exchange.asmx"
@@ -78,6 +84,7 @@ class Configuration:
         self.version = version
         self.retry_policy = retry_policy
         self.max_connections = max_connections
+        self.verify = verify
 
     @property
     def credentials(self):

--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -148,6 +148,10 @@ class BaseProtocol:
     def server(self):
         return self.config.server
 
+    @property
+    def verify(self):
+        return self.config.verify
+
     def __getstate__(self):
         # The session pool and lock cannot be pickled
         state = self.__dict__.copy()
@@ -306,6 +310,7 @@ class BaseProtocol:
                 raise ValueError(f"Auth type {self.auth_type!r} requires credentials")
             session = self.raw_session(self.service_endpoint)
             session.auth = get_auth_instance(auth_type=self.auth_type)
+            session.verify = self.config.verify
         else:
             if isinstance(self.credentials, BaseOAuth2Credentials):
                 with self.credentials.lock:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -41,6 +41,10 @@ class ConfigurationTest(TimedTestCase):
             Configuration(max_connections="foo")
         self.assertEqual(e.exception.args[0], "'max_connections' 'foo' must be of type <class 'int'>")
         self.assertEqual(Configuration().server, None)  # Test that property works when service_endpoint is None
+        with self.assertRaises(TypeError) as e:
+            Configuration(verify="foo")
+        self.assertEqual(e.exception.args[0], "'verify' 'foo' must be of type <class 'bool'>")
+        self.assertEqual(Configuration().verify, True)  # Test that property works when service_endpoint is None
 
     def test_magic(self):
         config = Configuration(

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -86,6 +86,7 @@ class ProtocolTest(EWSTest):
                 version=kwargs.get("version", Version(Build(15, 1))),
                 retry_policy=kwargs.get("retry_policy", FailFast()),
                 max_connections=kwargs.get("max_connections"),
+                verify=kwargs.get("verify", True),
             )
         )
 


### PR DESCRIPTION
Hey, thanks for taking the time to consider this pull request!

I have a use case where I need to be able to access the server over a https with self-signed certificate.
Currently exchangelib does not support this, so I went ahead and implemented it.

I added a value named 'verify' to the Configuration class that is True by default.
This value is used to set the verify attribute of the OAuth2 or requests.Session in Protocol. 
This attribute decides whether a connection with non-verifiable certificate is aborted or not. Its default is True, so the new configuration value will not disrupt any existing setups and other software relying on exchangelib.

I also adapted the tests to cover this behavior. As far as I was able to run them, they passed. 